### PR TITLE
feat: Notebookサービスとリポジトリの実装

### DIFF
--- a/notebooklm_enterprise_experiments_py/application/dto/__init__.py
+++ b/notebooklm_enterprise_experiments_py/application/dto/__init__.py
@@ -1,1 +1,19 @@
 """データ転送オブジェクト: レイヤー間のデータ転送に使用。"""
+
+from notebooklm_enterprise_experiments_py.application.dto.notebook_dto import (
+    AddSourcesRequest,
+    AskRequest,
+    AskResponse,
+    CitationDto,
+    CreateNotebookRequest,
+    CreateNotebookResponse,
+)
+
+__all__ = [
+    "CreateNotebookRequest",
+    "CreateNotebookResponse",
+    "AddSourcesRequest",
+    "AskRequest",
+    "AskResponse",
+    "CitationDto",
+]

--- a/notebooklm_enterprise_experiments_py/application/dto/notebook_dto.py
+++ b/notebooklm_enterprise_experiments_py/application/dto/notebook_dto.py
@@ -1,0 +1,51 @@
+"""Notebook関連のDTO。"""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class CreateNotebookRequest:
+    """ノートブック作成リクエストDTO。"""
+
+    notebook_id: str
+    display_name: str
+
+
+@dataclass
+class CreateNotebookResponse:
+    """ノートブック作成レスポンスDTO。"""
+
+    notebook_id: str
+    display_name: str
+
+
+@dataclass
+class AddSourcesRequest:
+    """ソース追加リクエストDTO。"""
+
+    notebook_id: str
+    source_uris: list[str]
+
+
+@dataclass
+class AskRequest:
+    """質問リクエストDTO。"""
+
+    notebook_id: str
+    query: str
+
+
+@dataclass
+class CitationDto:
+    """引用情報DTO。"""
+
+    source_title: str
+    content: str
+
+
+@dataclass
+class AskResponse:
+    """質問レスポンスDTO。"""
+
+    answer_text: str
+    citations: list[CitationDto]

--- a/notebooklm_enterprise_experiments_py/application/services/__init__.py
+++ b/notebooklm_enterprise_experiments_py/application/services/__init__.py
@@ -1,1 +1,9 @@
 """アプリケーションサービス: ユースケースの実装。"""
+
+from notebooklm_enterprise_experiments_py.application.services.notebook_service import (
+    NotebookService,
+)
+
+__all__ = [
+    "NotebookService",
+]

--- a/notebooklm_enterprise_experiments_py/application/services/notebook_service.py
+++ b/notebooklm_enterprise_experiments_py/application/services/notebook_service.py
@@ -1,0 +1,98 @@
+"""NotebookService: ノートブック関連のユースケースを実装する。"""
+
+from notebooklm_enterprise_experiments_py.application.dto.notebook_dto import (
+    AddSourcesRequest,
+    AskRequest,
+    AskResponse,
+    CitationDto,
+    CreateNotebookRequest,
+    CreateNotebookResponse,
+)
+from notebooklm_enterprise_experiments_py.domain.repositories.notebook_repository import (
+    NotebookRepository,
+)
+from notebooklm_enterprise_experiments_py.domain.value_objects.notebook_id import (
+    NotebookId,
+)
+from notebooklm_enterprise_experiments_py.domain.value_objects.query import Query
+
+
+class NotebookService:
+    """ノートブック関連のユースケースを実装するサービス。"""
+
+    def __init__(self, repository: NotebookRepository) -> None:
+        """NotebookServiceを初期化する。
+
+        Args:
+            repository: NotebookRepository
+        """
+        self.repository = repository
+
+    def create_notebook(
+        self,
+        request: CreateNotebookRequest,
+    ) -> CreateNotebookResponse:
+        """ノートブックを作成する。
+
+        Args:
+            request: ノートブック作成リクエスト
+
+        Returns:
+            ノートブック作成レスポンス
+        """
+        notebook_id = NotebookId(request.notebook_id)
+        notebook = self.repository.create(
+            notebook_id=notebook_id,
+            display_name=request.display_name,
+        )
+
+        return CreateNotebookResponse(
+            notebook_id=str(notebook.notebook_id),
+            display_name=notebook.display_name,
+        )
+
+    def add_sources(
+        self,
+        request: AddSourcesRequest,
+    ) -> None:
+        """ノートブックにソースを追加する。
+
+        Args:
+            request: ソース追加リクエスト
+        """
+        notebook_id = NotebookId(request.notebook_id)
+        self.repository.add_sources(
+            notebook_id=notebook_id,
+            source_uris=request.source_uris,
+        )
+
+    def ask(
+        self,
+        request: AskRequest,
+    ) -> AskResponse:
+        """ノートブックに質問する。
+
+        Args:
+            request: 質問リクエスト
+
+        Returns:
+            質問レスポンス
+        """
+        notebook_id = NotebookId(request.notebook_id)
+        query = Query(request.query)
+
+        answer = self.repository.ask(
+            notebook_id=notebook_id,
+            query=query,
+        )
+
+        return AskResponse(
+            answer_text=answer.answer_text,
+            citations=[
+                CitationDto(
+                    source_title=citation.source_title,
+                    content=citation.content,
+                )
+                for citation in answer.citations
+            ],
+        )

--- a/notebooklm_enterprise_experiments_py/domain/entities/__init__.py
+++ b/notebooklm_enterprise_experiments_py/domain/entities/__init__.py
@@ -1,1 +1,7 @@
 """ドメインエンティティ: 一意の識別子を持つドメインオブジェクト。"""
+
+from notebooklm_enterprise_experiments_py.domain.entities.notebook import Notebook
+
+__all__ = [
+    "Notebook",
+]

--- a/notebooklm_enterprise_experiments_py/domain/entities/notebook.py
+++ b/notebooklm_enterprise_experiments_py/domain/entities/notebook.py
@@ -1,0 +1,39 @@
+"""Notebookエンティティ。"""
+
+from dataclasses import dataclass, field
+
+from notebooklm_enterprise_experiments_py.domain.value_objects.notebook_id import (
+    NotebookId,
+)
+
+
+@dataclass
+class Notebook:
+    """Notebook（ノートブック）を表すエンティティ。"""
+
+    notebook_id: NotebookId
+    display_name: str
+    sources: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        """値の検証を行う。"""
+        if not isinstance(self.display_name, str):
+            raise ValueError("display_nameは文字列である必要があります。")
+        if not self.display_name:
+            raise ValueError("display_nameは空文字列にできません。")
+        if not isinstance(self.sources, list):
+            raise ValueError("sourcesはリストである必要があります。")
+        for source in self.sources:
+            if not isinstance(source, str):
+                raise ValueError("sourcesの要素は文字列である必要があります。")
+
+    def add_source(self, source_uri: str) -> None:
+        """ソースURIを追加する。
+
+        Args:
+            source_uri: 追加するソースURI
+        """
+        if not isinstance(source_uri, str):
+            raise ValueError("source_uriは文字列である必要があります。")
+        if source_uri not in self.sources:
+            self.sources.append(source_uri)

--- a/notebooklm_enterprise_experiments_py/domain/repositories/__init__.py
+++ b/notebooklm_enterprise_experiments_py/domain/repositories/__init__.py
@@ -1,1 +1,9 @@
 """リポジトリインターフェース: ドメインオブジェクトの永続化に関する抽象化。"""
+
+from notebooklm_enterprise_experiments_py.domain.repositories.notebook_repository import (
+    NotebookRepository,
+)
+
+__all__ = [
+    "NotebookRepository",
+]

--- a/notebooklm_enterprise_experiments_py/domain/repositories/notebook_repository.py
+++ b/notebooklm_enterprise_experiments_py/domain/repositories/notebook_repository.py
@@ -1,0 +1,62 @@
+"""NotebookRepositoryインターフェース。"""
+
+from abc import ABC, abstractmethod
+
+from notebooklm_enterprise_experiments_py.domain.entities.notebook import Notebook
+from notebooklm_enterprise_experiments_py.domain.value_objects.answer import Answer
+from notebooklm_enterprise_experiments_py.domain.value_objects.notebook_id import (
+    NotebookId,
+)
+from notebooklm_enterprise_experiments_py.domain.value_objects.query import Query
+
+
+class NotebookRepository(ABC):
+    """Notebookリポジトリのインターフェース。"""
+
+    @abstractmethod
+    def create(
+        self,
+        notebook_id: NotebookId,
+        display_name: str,
+    ) -> Notebook:
+        """ノートブックを作成する。
+
+        Args:
+            notebook_id: ノートブックID
+            display_name: 表示名
+
+        Returns:
+            作成されたノートブック
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def add_sources(
+        self,
+        notebook_id: NotebookId,
+        source_uris: list[str],
+    ) -> None:
+        """ノートブックにソースを追加する。
+
+        Args:
+            notebook_id: ノートブックID
+            source_uris: 追加するソースURIのリスト
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def ask(
+        self,
+        notebook_id: NotebookId,
+        query: Query,
+    ) -> Answer:
+        """ノートブックに質問する。
+
+        Args:
+            notebook_id: ノートブックID
+            query: クエリ（質問）
+
+        Returns:
+            回答
+        """
+        raise NotImplementedError

--- a/notebooklm_enterprise_experiments_py/domain/value_objects/__init__.py
+++ b/notebooklm_enterprise_experiments_py/domain/value_objects/__init__.py
@@ -1,1 +1,17 @@
 """値オブジェクト: 識別子を持たない不変のドメインオブジェクト。"""
+
+from notebooklm_enterprise_experiments_py.domain.value_objects.answer import (
+    Answer,
+    Citation,
+)
+from notebooklm_enterprise_experiments_py.domain.value_objects.notebook_id import (
+    NotebookId,
+)
+from notebooklm_enterprise_experiments_py.domain.value_objects.query import Query
+
+__all__ = [
+    "NotebookId",
+    "Query",
+    "Answer",
+    "Citation",
+]

--- a/notebooklm_enterprise_experiments_py/domain/value_objects/answer.py
+++ b/notebooklm_enterprise_experiments_py/domain/value_objects/answer.py
@@ -1,0 +1,40 @@
+"""Answer値オブジェクト。"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Citation:
+    """引用情報を表す値オブジェクト。"""
+
+    source_title: str
+    content: str
+
+    def __post_init__(self) -> None:
+        """値の検証を行う。"""
+        if not isinstance(self.source_title, str):
+            raise ValueError("source_titleは文字列である必要があります。")
+        if not isinstance(self.content, str):
+            raise ValueError("contentは文字列である必要があります。")
+
+
+@dataclass(frozen=True)
+class Answer:
+    """回答を表す値オブジェクト。"""
+
+    answer_text: str
+    citations: tuple[Citation, ...] = ()
+
+    def __post_init__(self) -> None:
+        """値の検証を行う。"""
+        if not isinstance(self.answer_text, str):
+            raise ValueError("answer_textは文字列である必要があります。")
+        if not isinstance(self.citations, tuple):
+            raise ValueError("citationsはタプルである必要があります。")
+        for citation in self.citations:
+            if not isinstance(citation, Citation):
+                raise ValueError("citationsの要素はCitationである必要があります。")
+
+    def __str__(self) -> str:
+        """文字列表現を返す。"""
+        return self.answer_text

--- a/notebooklm_enterprise_experiments_py/domain/value_objects/notebook_id.py
+++ b/notebooklm_enterprise_experiments_py/domain/value_objects/notebook_id.py
@@ -1,0 +1,21 @@
+"""Notebook ID値オブジェクト。"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class NotebookId:
+    """Notebook IDを表す値オブジェクト。"""
+
+    value: str
+
+    def __post_init__(self) -> None:
+        """値の検証を行う。"""
+        if not self.value:
+            raise ValueError("NotebookIdは空文字列にできません。")
+        if not isinstance(self.value, str):
+            raise ValueError("NotebookIdは文字列である必要があります。")
+
+    def __str__(self) -> str:
+        """文字列表現を返す。"""
+        return self.value

--- a/notebooklm_enterprise_experiments_py/domain/value_objects/query.py
+++ b/notebooklm_enterprise_experiments_py/domain/value_objects/query.py
@@ -1,0 +1,21 @@
+"""Query値オブジェクト。"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Query:
+    """クエリ（質問）を表す値オブジェクト。"""
+
+    text: str
+
+    def __post_init__(self) -> None:
+        """値の検証を行う。"""
+        if not self.text:
+            raise ValueError("Queryは空文字列にできません。")
+        if not isinstance(self.text, str):
+            raise ValueError("Queryは文字列である必要があります。")
+
+    def __str__(self) -> str:
+        """文字列表現を返す。"""
+        return self.text

--- a/notebooklm_enterprise_experiments_py/infrastructure/config/__init__.py
+++ b/notebooklm_enterprise_experiments_py/infrastructure/config/__init__.py
@@ -5,6 +5,8 @@ from notebooklm_enterprise_experiments_py.infrastructure.config.env_config impor
     get_gcp_location,
     get_gcp_project_id,
     get_gcp_region,
+    get_service_account_key_info,
+    get_service_account_key_path,
 )
 
 __all__ = [
@@ -12,4 +14,6 @@ __all__ = [
     "get_gcp_project_id",
     "get_gcp_region",
     "get_gcp_location",
+    "get_service_account_key_path",
+    "get_service_account_key_info",
 ]

--- a/notebooklm_enterprise_experiments_py/infrastructure/config/env_config.py
+++ b/notebooklm_enterprise_experiments_py/infrastructure/config/env_config.py
@@ -1,5 +1,6 @@
 """環境変数の設定と読み込みを行うモジュール。"""
 
+import json
 import os
 from pathlib import Path
 
@@ -72,3 +73,34 @@ def get_gcp_location(default: str = "global") -> str:
     """
     result = get_env("GCP_LOCATION", default)
     return result if result is not None else default
+
+
+def get_service_account_key_path() -> str | None:
+    """
+    サービスアカウントキーのファイルパスを取得する。
+
+    Returns:
+        サービスアカウントキーのファイルパス、またはNone
+    """
+    return get_env("GCP_SERVICE_ACCOUNT_KEY_PATH")
+
+
+def get_service_account_key_info() -> dict | None:
+    """
+    サービスアカウントキーの情報を辞書として取得する。
+
+    環境変数GCP_SERVICE_ACCOUNT_KEY_JSONにJSON文字列が設定されている場合、
+    それをパースして返す。
+
+    Returns:
+        サービスアカウントキーの情報を表す辞書、またはNone
+    """
+    key_json = get_env("GCP_SERVICE_ACCOUNT_KEY_JSON")
+    if key_json:
+        try:
+            return json.loads(key_json)
+        except json.JSONDecodeError as e:
+            raise ValueError(
+                f"GCP_SERVICE_ACCOUNT_KEY_JSONの形式が不正です: {e}"
+            ) from e
+    return None

--- a/notebooklm_enterprise_experiments_py/infrastructure/external/__init__.py
+++ b/notebooklm_enterprise_experiments_py/infrastructure/external/__init__.py
@@ -1,1 +1,9 @@
 """外部サービス連携: GCPなどの外部サービスとの通信。"""
+
+from notebooklm_enterprise_experiments_py.infrastructure.external.notebooklm_client import (
+    NotebookLMClient,
+)
+
+__all__ = [
+    "NotebookLMClient",
+]

--- a/notebooklm_enterprise_experiments_py/infrastructure/external/notebooklm_client.py
+++ b/notebooklm_enterprise_experiments_py/infrastructure/external/notebooklm_client.py
@@ -1,0 +1,159 @@
+"""NotebookLMクライアント（Google Cloud Discovery Engine）。"""
+
+from typing import Any
+
+from pathlib import Path
+
+from google.cloud import discoveryengine_v1alpha as discoveryengine
+from google.oauth2 import service_account
+
+from notebooklm_enterprise_experiments_py.infrastructure.config.env_config import (
+    get_service_account_key_info,
+    get_service_account_key_path,
+)
+
+
+class NotebookLMClient:
+    """NotebookLM（Google Cloud Discovery Engine）との通信を行うクライアント。"""
+
+    def __init__(
+        self,
+        project_id: str,
+        location: str,
+        credentials: service_account.Credentials | None = None,
+    ) -> None:
+        """NotebookLMClientを初期化する。
+
+        Args:
+            project_id: GCPプロジェクトID
+            location: GCPロケーション（例: "global"）
+            credentials: サービスアカウント認証情報（Noneの場合は環境変数から取得）
+        """
+        self.project_id = project_id
+        self.location = location
+
+        if credentials is None:
+            credentials = self._load_credentials()
+
+        self.notebook_client = discoveryengine.NotebookServiceClient(
+            credentials=credentials
+        )
+        self.conversational_search_client = (
+            discoveryengine.ConversationalSearchServiceClient(credentials=credentials)
+        )
+
+    def _load_credentials(self) -> service_account.Credentials:
+        """環境変数からサービスアカウント認証情報を読み込む。
+
+        Returns:
+            サービスアカウント認証情報
+
+        Raises:
+            ValueError: 認証情報が設定されていない場合
+        """
+        # まず、JSON文字列から読み込むことを試みる
+        key_info = get_service_account_key_info()
+        if key_info:
+            return service_account.Credentials.from_service_account_info(key_info)
+
+        # 次に、ファイルパスから読み込むことを試みる
+        key_path = get_service_account_key_path()
+        if key_path:
+            key_path_obj = Path(key_path)
+            if not key_path_obj.exists():
+                raise ValueError(
+                    f"サービスアカウントキーファイルが見つかりません: {key_path}"
+                )
+            return service_account.Credentials.from_service_account_file(
+                str(key_path_obj)
+            )
+
+        raise ValueError(
+            "サービスアカウント認証情報が設定されていません。"
+            "GCP_SERVICE_ACCOUNT_KEY_PATHまたはGCP_SERVICE_ACCOUNT_KEY_JSONを設定してください。"
+        )
+
+    def create_notebook(
+        self,
+        notebook_id: str,
+        display_name: str,
+    ) -> Any:
+        """ノートブックを作成する。
+
+        Args:
+            notebook_id: ノートブックID
+            display_name: 表示名
+
+        Returns:
+            作成されたノートブック
+        """
+        parent = f"projects/{self.project_id}/locations/{self.location}"
+
+        notebook = discoveryengine.Notebook(display_name=display_name)
+
+        request = discoveryengine.CreateNotebookRequest(
+            parent=parent,
+            notebook=notebook,
+            notebook_id=notebook_id,
+        )
+
+        response = self.notebook_client.create_notebook(request=request)
+        return response
+
+    def add_sources(
+        self,
+        notebook_id: str,
+        source_uris: list[str],
+    ) -> None:
+        """ノートブックにソースを追加する。
+
+        Args:
+            notebook_id: ノートブックID
+            source_uris: 追加するソースURIのリスト（GCS URI）
+        """
+        name = (
+            f"projects/{self.project_id}/locations/{self.location}/notebooks/{notebook_id}"
+        )
+
+        request = discoveryengine.ImportNotebookSourcesRequest(
+            parent=name,
+            gcs_source=discoveryengine.GcsSource(uris=source_uris),
+        )
+
+        operation = self.notebook_client.import_notebook_sources(request=request)
+        operation.result()  # 操作が完了するまで待機
+
+    def ask(
+        self,
+        notebook_id: str,
+        query_text: str,
+        include_citations: bool = True,
+    ) -> Any:
+        """ノートブックに質問する。
+
+        Args:
+            notebook_id: ノートブックID
+            query_text: 質問テキスト
+            include_citations: 引用を含めるかどうか
+
+        Returns:
+            回答レスポンス
+        """
+        serving_config = (
+            f"projects/{self.project_id}/locations/{self.location}/"
+            f"collections/default_collection/engines/{notebook_id}/"
+            f"servingConfigs/default_serving_config"
+        )
+
+        request = discoveryengine.AnswerRequest(
+            serving_config=serving_config,
+            query=discoveryengine.Query(text=query_text),
+            answer_generation_spec=discoveryengine.AnswerRequest.AnswerGenerationSpec(
+                include_citations=include_citations
+            )
+            if include_citations
+            else None,
+        )
+
+        response = self.conversational_search_client.answer(request=request)
+        return response

--- a/notebooklm_enterprise_experiments_py/infrastructure/repositories/__init__.py
+++ b/notebooklm_enterprise_experiments_py/infrastructure/repositories/__init__.py
@@ -1,1 +1,9 @@
 """リポジトリ実装: ドメインリポジトリインターフェースの具体的な実装。"""
+
+from notebooklm_enterprise_experiments_py.infrastructure.repositories.notebook_repository_impl import (
+    NotebookRepositoryImpl,
+)
+
+__all__ = [
+    "NotebookRepositoryImpl",
+]

--- a/notebooklm_enterprise_experiments_py/infrastructure/repositories/notebook_repository_impl.py
+++ b/notebooklm_enterprise_experiments_py/infrastructure/repositories/notebook_repository_impl.py
@@ -1,0 +1,108 @@
+"""NotebookRepositoryの実装。"""
+
+from notebooklm_enterprise_experiments_py.domain.entities.notebook import Notebook
+from notebooklm_enterprise_experiments_py.domain.repositories.notebook_repository import (
+    NotebookRepository,
+)
+from notebooklm_enterprise_experiments_py.domain.value_objects.answer import (
+    Answer,
+    Citation,
+)
+from notebooklm_enterprise_experiments_py.domain.value_objects.notebook_id import (
+    NotebookId,
+)
+from notebooklm_enterprise_experiments_py.domain.value_objects.query import Query
+from notebooklm_enterprise_experiments_py.infrastructure.external.notebooklm_client import (
+    NotebookLMClient,
+)
+
+
+class NotebookRepositoryImpl(NotebookRepository):
+    """NotebookRepositoryの実装。"""
+
+    def __init__(
+        self,
+        client: NotebookLMClient,
+    ) -> None:
+        """NotebookRepositoryImplを初期化する。
+
+        Args:
+            client: NotebookLMClient
+        """
+        self.client = client
+
+    def create(
+        self,
+        notebook_id: NotebookId,
+        display_name: str,
+    ) -> Notebook:
+        """ノートブックを作成する。
+
+        Args:
+            notebook_id: ノートブックID
+            display_name: 表示名
+
+        Returns:
+            作成されたノートブック
+        """
+        response = self.client.create_notebook(
+            notebook_id=str(notebook_id),
+            display_name=display_name,
+        )
+
+        return Notebook(
+            notebook_id=notebook_id,
+            display_name=display_name,
+            sources=[],
+        )
+
+    def add_sources(
+        self,
+        notebook_id: NotebookId,
+        source_uris: list[str],
+    ) -> None:
+        """ノートブックにソースを追加する。
+
+        Args:
+            notebook_id: ノートブックID
+            source_uris: 追加するソースURIのリスト
+        """
+        self.client.add_sources(
+            notebook_id=str(notebook_id),
+            source_uris=source_uris,
+        )
+
+    def ask(
+        self,
+        notebook_id: NotebookId,
+        query: Query,
+    ) -> Answer:
+        """ノートブックに質問する。
+
+        Args:
+            notebook_id: ノートブックID
+            query: クエリ（質問）
+
+        Returns:
+            回答
+        """
+        response = self.client.ask(
+            notebook_id=str(notebook_id),
+            query_text=str(query),
+            include_citations=True,
+        )
+
+        # Google Cloud Discovery EngineのAPIレスポンス構造に合わせて処理
+        answer = response.answer
+        citations = tuple(
+            Citation(
+                source_title=citation.source_title,
+                content=citation.content,
+            )
+            for citation in answer.citations
+        )
+
+        return Answer(
+            answer_text=answer.answer_text,
+            citations=citations,
+        )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,56 @@
+"""設定管理モジュールのテスト。"""
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from notebooklm_enterprise_experiments_py.infrastructure.config import env_config
+
+
+class TestServiceAccountKey:
+    """サービスアカウントキー関連のテスト。"""
+
+    def test_get_service_account_key_path_with_env(self) -> None:
+        """環境変数からサービスアカウントキーパスを取得できる。"""
+        with patch.dict(
+            os.environ, {"GCP_SERVICE_ACCOUNT_KEY_PATH": "/path/to/key.json"}
+        ):
+            result = env_config.get_service_account_key_path()
+            assert result == "/path/to/key.json"
+
+    def test_get_service_account_key_path_without_env(self) -> None:
+        """環境変数が設定されていない場合はNoneを返す。"""
+        with patch.dict(os.environ, {}, clear=True):
+            result = env_config.get_service_account_key_path()
+            assert result is None
+
+    def test_get_service_account_key_info_with_valid_json(self) -> None:
+        """有効なJSON文字列からサービスアカウントキー情報を取得できる。"""
+        key_info = {
+            "type": "service_account",
+            "project_id": "test-project",
+            "private_key_id": "test-key-id",
+        }
+        with patch.dict(
+            os.environ,
+            {"GCP_SERVICE_ACCOUNT_KEY_JSON": json.dumps(key_info)},
+        ):
+            result = env_config.get_service_account_key_info()
+            assert result == key_info
+
+    def test_get_service_account_key_info_with_invalid_json(self) -> None:
+        """無効なJSON文字列はエラーを発生させる。"""
+        with patch.dict(
+            os.environ, {"GCP_SERVICE_ACCOUNT_KEY_JSON": "invalid json"}
+        ):
+            with pytest.raises(ValueError, match="GCP_SERVICE_ACCOUNT_KEY_JSONの形式が不正です"):
+                env_config.get_service_account_key_info()
+
+    def test_get_service_account_key_info_without_env(self) -> None:
+        """環境変数が設定されていない場合はNoneを返す。"""
+        with patch.dict(os.environ, {}, clear=True):
+            result = env_config.get_service_account_key_info()
+            assert result is None

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1,0 +1,104 @@
+"""エンティティのテスト。"""
+
+import pytest
+
+from notebooklm_enterprise_experiments_py.domain.entities.notebook import Notebook
+from notebooklm_enterprise_experiments_py.domain.value_objects.notebook_id import (
+    NotebookId,
+)
+
+
+class TestNotebook:
+    """Notebookエンティティのテスト。"""
+
+    def test_valid_notebook(self) -> None:
+        """有効なNotebookを作成できる。"""
+        notebook_id = NotebookId("test-notebook-123")
+        notebook = Notebook(
+            notebook_id=notebook_id,
+            display_name="テストノートブック",
+        )
+        assert notebook.notebook_id == notebook_id
+        assert notebook.display_name == "テストノートブック"
+        assert notebook.sources == []
+
+    def test_notebook_with_sources(self) -> None:
+        """ソース付きのNotebookを作成できる。"""
+        notebook_id = NotebookId("test-notebook-123")
+        notebook = Notebook(
+            notebook_id=notebook_id,
+            display_name="テストノートブック",
+            sources=["gs://bucket/doc1.pdf", "gs://bucket/doc2.pdf"],
+        )
+        assert len(notebook.sources) == 2
+        assert "gs://bucket/doc1.pdf" in notebook.sources
+        assert "gs://bucket/doc2.pdf" in notebook.sources
+
+    def test_empty_display_name_raises_error(self) -> None:
+        """空文字列のdisplay_nameはエラーを発生させる。"""
+        notebook_id = NotebookId("test-notebook-123")
+        with pytest.raises(ValueError, match="display_nameは空文字列にできません"):
+            Notebook(
+                notebook_id=notebook_id,
+                display_name="",
+            )
+
+    def test_non_string_display_name_raises_error(self) -> None:
+        """文字列以外のdisplay_nameはエラーを発生させる。"""
+        notebook_id = NotebookId("test-notebook-123")
+        with pytest.raises(ValueError, match="display_nameは文字列である必要があります"):
+            Notebook(
+                notebook_id=notebook_id,
+                display_name=123,  # type: ignore[arg-type]
+            )
+
+    def test_non_list_sources_raises_error(self) -> None:
+        """リスト以外のsourcesはエラーを発生させる。"""
+        notebook_id = NotebookId("test-notebook-123")
+        with pytest.raises(ValueError, match="sourcesはリストである必要があります"):
+            Notebook(
+                notebook_id=notebook_id,
+                display_name="テストノートブック",
+                sources="invalid",  # type: ignore[arg-type]
+            )
+
+    def test_non_string_source_uri_raises_error(self) -> None:
+        """文字列以外のソースURIはエラーを発生させる。"""
+        notebook_id = NotebookId("test-notebook-123")
+        with pytest.raises(ValueError, match="sourcesの要素は文字列である必要があります"):
+            Notebook(
+                notebook_id=notebook_id,
+                display_name="テストノートブック",
+                sources=[123],  # type: ignore[list-item]
+            )
+
+    def test_add_source(self) -> None:
+        """ソースURIを追加できる。"""
+        notebook_id = NotebookId("test-notebook-123")
+        notebook = Notebook(
+            notebook_id=notebook_id,
+            display_name="テストノートブック",
+        )
+        notebook.add_source("gs://bucket/doc1.pdf")
+        assert "gs://bucket/doc1.pdf" in notebook.sources
+
+    def test_add_duplicate_source(self) -> None:
+        """重複するソースURIは追加されない。"""
+        notebook_id = NotebookId("test-notebook-123")
+        notebook = Notebook(
+            notebook_id=notebook_id,
+            display_name="テストノートブック",
+        )
+        notebook.add_source("gs://bucket/doc1.pdf")
+        notebook.add_source("gs://bucket/doc1.pdf")
+        assert notebook.sources.count("gs://bucket/doc1.pdf") == 1
+
+    def test_add_non_string_source_raises_error(self) -> None:
+        """文字列以外のソースURIはエラーを発生させる。"""
+        notebook_id = NotebookId("test-notebook-123")
+        notebook = Notebook(
+            notebook_id=notebook_id,
+            display_name="テストノートブック",
+        )
+        with pytest.raises(ValueError, match="source_uriは文字列である必要があります"):
+            notebook.add_source(123)  # type: ignore[arg-type]

--- a/tests/test_notebook_repository.py
+++ b/tests/test_notebook_repository.py
@@ -1,0 +1,116 @@
+"""NotebookRepositoryのテスト。"""
+
+from unittest.mock import MagicMock, Mock
+
+import pytest
+
+from notebooklm_enterprise_experiments_py.domain.entities.notebook import Notebook
+from notebooklm_enterprise_experiments_py.domain.repositories.notebook_repository import (
+    NotebookRepository,
+)
+from notebooklm_enterprise_experiments_py.domain.value_objects.answer import (
+    Answer,
+    Citation,
+)
+from notebooklm_enterprise_experiments_py.domain.value_objects.notebook_id import (
+    NotebookId,
+)
+from notebooklm_enterprise_experiments_py.domain.value_objects.query import Query
+from notebooklm_enterprise_experiments_py.infrastructure.external.notebooklm_client import (
+    NotebookLMClient,
+)
+from notebooklm_enterprise_experiments_py.infrastructure.repositories.notebook_repository_impl import (
+    NotebookRepositoryImpl,
+)
+
+
+class TestNotebookRepositoryImpl:
+    """NotebookRepositoryImplのテスト。"""
+
+    @pytest.fixture
+    def mock_client(self) -> Mock:
+        """モッククライアントを作成する。"""
+        return Mock(spec=NotebookLMClient)
+
+    @pytest.fixture
+    def repository(self, mock_client: Mock) -> NotebookRepositoryImpl:
+        """NotebookRepositoryImplのインスタンスを作成する。"""
+        return NotebookRepositoryImpl(client=mock_client)
+
+    def test_create(
+        self, repository: NotebookRepositoryImpl, mock_client: Mock
+    ) -> None:
+        """ノートブックを作成できる。"""
+        mock_response = Mock()
+        mock_client.create_notebook = MagicMock(return_value=mock_response)
+
+        notebook_id = NotebookId("test-notebook")
+        notebook = repository.create(
+            notebook_id=notebook_id,
+            display_name="テストノートブック",
+        )
+
+        assert isinstance(notebook, Notebook)
+        assert notebook.notebook_id == notebook_id
+        assert notebook.display_name == "テストノートブック"
+        mock_client.create_notebook.assert_called_once_with(
+            notebook_id="test-notebook",
+            display_name="テストノートブック",
+        )
+
+    def test_add_sources(
+        self, repository: NotebookRepositoryImpl, mock_client: Mock
+    ) -> None:
+        """ソースを追加できる。"""
+        mock_operation = Mock()
+        mock_operation.result = MagicMock(return_value=None)
+        mock_client.add_sources = MagicMock()
+
+        notebook_id = NotebookId("test-notebook")
+        repository.add_sources(
+            notebook_id=notebook_id,
+            source_uris=["gs://bucket/doc1.pdf"],
+        )
+
+        mock_client.add_sources.assert_called_once_with(
+            notebook_id="test-notebook",
+            source_uris=["gs://bucket/doc1.pdf"],
+        )
+
+    def test_ask(
+        self, repository: NotebookRepositoryImpl, mock_client: Mock
+    ) -> None:
+        """質問できる。"""
+        mock_citation = Mock()
+        mock_citation.source_title = "ドキュメント1"
+        mock_citation.content = "内容1"
+        mock_answer = Mock()
+        mock_answer.answer_text = "これは回答です。"
+        mock_answer.citations = [mock_citation]
+        mock_response = Mock()
+        mock_response.answer = mock_answer
+        mock_client.ask = MagicMock(return_value=mock_response)
+
+        notebook_id = NotebookId("test-notebook")
+        query = Query("最新の売上状況は？")
+        answer = repository.ask(notebook_id=notebook_id, query=query)
+
+        assert isinstance(answer, Answer)
+        assert answer.answer_text == "これは回答です。"
+        assert len(answer.citations) == 1
+        assert answer.citations[0].source_title == "ドキュメント1"
+        assert answer.citations[0].content == "内容1"
+        mock_client.ask.assert_called_once_with(
+            notebook_id="test-notebook",
+            query_text="最新の売上状況は？",
+            include_citations=True,
+        )
+
+
+class TestNotebookRepository:
+    """NotebookRepositoryインターフェースのテスト。"""
+
+    def test_notebook_repository_is_abstract(self) -> None:
+        """NotebookRepositoryは抽象クラスである。"""
+        with pytest.raises(TypeError):
+            NotebookRepository()  # type: ignore[abstract]

--- a/tests/test_notebook_service.py
+++ b/tests/test_notebook_service.py
@@ -1,0 +1,105 @@
+"""NotebookServiceのテスト。"""
+
+from unittest.mock import Mock
+
+import pytest
+
+from notebooklm_enterprise_experiments_py.application.dto.notebook_dto import (
+    AddSourcesRequest,
+    AskRequest,
+    CreateNotebookRequest,
+)
+from notebooklm_enterprise_experiments_py.application.services.notebook_service import (
+    NotebookService,
+)
+from notebooklm_enterprise_experiments_py.domain.entities.notebook import Notebook
+from notebooklm_enterprise_experiments_py.domain.repositories.notebook_repository import (
+    NotebookRepository,
+)
+from notebooklm_enterprise_experiments_py.domain.value_objects.answer import (
+    Answer,
+    Citation,
+)
+from notebooklm_enterprise_experiments_py.domain.value_objects.notebook_id import (
+    NotebookId,
+)
+from notebooklm_enterprise_experiments_py.domain.value_objects.query import Query
+
+
+class TestNotebookService:
+    """NotebookServiceのテスト。"""
+
+    @pytest.fixture
+    def mock_repository(self) -> Mock:
+        """モックリポジトリを作成する。"""
+        return Mock(spec=NotebookRepository)
+
+    @pytest.fixture
+    def service(self, mock_repository: Mock) -> NotebookService:
+        """NotebookServiceのインスタンスを作成する。"""
+        return NotebookService(repository=mock_repository)
+
+    def test_create_notebook(
+        self, service: NotebookService, mock_repository: Mock
+    ) -> None:
+        """ノートブックを作成できる。"""
+        notebook_id = NotebookId("test-notebook")
+        notebook = Notebook(
+            notebook_id=notebook_id,
+            display_name="テストノートブック",
+        )
+        mock_repository.create = Mock(return_value=notebook)
+
+        request = CreateNotebookRequest(
+            notebook_id="test-notebook",
+            display_name="テストノートブック",
+        )
+        response = service.create_notebook(request)
+
+        assert response.notebook_id == "test-notebook"
+        assert response.display_name == "テストノートブック"
+        mock_repository.create.assert_called_once()
+        call_args = mock_repository.create.call_args
+        assert call_args[1]["notebook_id"] == notebook_id
+        assert call_args[1]["display_name"] == "テストノートブック"
+
+    def test_add_sources(
+        self, service: NotebookService, mock_repository: Mock
+    ) -> None:
+        """ソースを追加できる。"""
+        mock_repository.add_sources = Mock()
+
+        request = AddSourcesRequest(
+            notebook_id="test-notebook",
+            source_uris=["gs://bucket/doc1.pdf"],
+        )
+        service.add_sources(request)
+
+        mock_repository.add_sources.assert_called_once()
+        call_args = mock_repository.add_sources.call_args
+        assert call_args[1]["notebook_id"] == NotebookId("test-notebook")
+        assert call_args[1]["source_uris"] == ["gs://bucket/doc1.pdf"]
+
+    def test_ask(self, service: NotebookService, mock_repository: Mock) -> None:
+        """質問できる。"""
+        citation = Citation(source_title="ドキュメント1", content="内容1")
+        answer = Answer(
+            answer_text="これは回答です。",
+            citations=(citation,),
+        )
+        mock_repository.ask = Mock(return_value=answer)
+
+        request = AskRequest(
+            notebook_id="test-notebook",
+            query="最新の売上状況は？",
+        )
+        response = service.ask(request)
+
+        assert response.answer_text == "これは回答です。"
+        assert len(response.citations) == 1
+        assert response.citations[0].source_title == "ドキュメント1"
+        assert response.citations[0].content == "内容1"
+        mock_repository.ask.assert_called_once()
+        call_args = mock_repository.ask.call_args
+        assert call_args[1]["notebook_id"] == NotebookId("test-notebook")
+        assert call_args[1]["query"] == Query("最新の売上状況は？")

--- a/tests/test_notebooklm_client.py
+++ b/tests/test_notebooklm_client.py
@@ -1,0 +1,244 @@
+"""NotebookLMClientのテスト。"""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+from google.oauth2 import service_account
+
+# モジュール全体をモックする前にインポート
+with patch(
+    "notebooklm_enterprise_experiments_py.infrastructure.external.notebooklm_client.discoveryengine"
+) as mock_discoveryengine:
+    mock_discoveryengine.NotebookServiceClient = Mock
+    mock_discoveryengine.ConversationalSearchServiceClient = Mock
+    mock_discoveryengine.Notebook = Mock
+    mock_discoveryengine.CreateNotebookRequest = Mock
+    mock_discoveryengine.ImportNotebookSourcesRequest = Mock
+    mock_discoveryengine.GcsSource = Mock
+    mock_discoveryengine.AnswerRequest = Mock
+    mock_discoveryengine.Query = Mock
+    mock_discoveryengine.AnswerRequest.AnswerGenerationSpec = Mock
+
+from notebooklm_enterprise_experiments_py.infrastructure.external.notebooklm_client import (
+    NotebookLMClient,
+)
+
+
+class TestNotebookLMClient:
+    """NotebookLMClientのテスト。"""
+
+    @pytest.fixture
+    def mock_credentials(self) -> service_account.Credentials:
+        """モック認証情報を作成する。"""
+        return Mock(spec=service_account.Credentials)
+
+    @pytest.fixture
+    def client(
+        self, mock_credentials: service_account.Credentials
+    ) -> NotebookLMClient:
+        """NotebookLMClientのインスタンスを作成する。"""
+        with patch(
+            "notebooklm_enterprise_experiments_py.infrastructure.external.notebooklm_client.discoveryengine.NotebookServiceClient",
+            return_value=Mock(),
+        ), patch(
+            "notebooklm_enterprise_experiments_py.infrastructure.external.notebooklm_client.discoveryengine.ConversationalSearchServiceClient",
+            return_value=Mock(),
+        ):
+            client = NotebookLMClient(
+                project_id="test-project",
+                location="global",
+                credentials=mock_credentials,
+            )
+            return client
+
+    def test_init_with_credentials(self, mock_credentials: service_account.Credentials) -> None:
+        """認証情報を指定して初期化できる。"""
+        with patch(
+            "notebooklm_enterprise_experiments_py.infrastructure.external.notebooklm_client.discoveryengine.NotebookServiceClient",
+            return_value=Mock(),
+        ), patch(
+            "notebooklm_enterprise_experiments_py.infrastructure.external.notebooklm_client.discoveryengine.ConversationalSearchServiceClient",
+            return_value=Mock(),
+        ):
+            client = NotebookLMClient(
+                project_id="test-project",
+                location="global",
+                credentials=mock_credentials,
+            )
+            assert client.project_id == "test-project"
+            assert client.location == "global"
+
+    def test_init_without_credentials_uses_env(self) -> None:
+        """認証情報が指定されていない場合は環境変数から読み込む。"""
+        key_info = {
+            "type": "service_account",
+            "project_id": "test-project",
+            "private_key_id": "test-key-id",
+        }
+        with patch(
+            "notebooklm_enterprise_experiments_py.infrastructure.external.notebooklm_client.get_service_account_key_info",
+            return_value=key_info,
+        ), patch(
+            "notebooklm_enterprise_experiments_py.infrastructure.external.notebooklm_client.service_account.Credentials.from_service_account_info",
+            return_value=Mock(spec=service_account.Credentials),
+        ), patch(
+            "notebooklm_enterprise_experiments_py.infrastructure.external.notebooklm_client.discoveryengine.NotebookServiceClient",
+            return_value=Mock(),
+        ), patch(
+            "notebooklm_enterprise_experiments_py.infrastructure.external.notebooklm_client.discoveryengine.ConversationalSearchServiceClient",
+            return_value=Mock(),
+        ):
+            client = NotebookLMClient(
+                project_id="test-project",
+                location="global",
+            )
+            assert client.project_id == "test-project"
+            assert client.location == "global"
+
+    def test_init_without_credentials_uses_file_path(self, tmp_path: Path) -> None:
+        """認証情報が指定されていない場合はファイルパスから読み込む。"""
+        key_file = tmp_path / "key.json"
+        key_file.write_text('{"type": "service_account"}')
+
+        with patch(
+            "notebooklm_enterprise_experiments_py.infrastructure.external.notebooklm_client.get_service_account_key_info",
+            return_value=None,
+        ), patch(
+            "notebooklm_enterprise_experiments_py.infrastructure.external.notebooklm_client.get_service_account_key_path",
+            return_value=str(key_file),
+        ), patch(
+            "notebooklm_enterprise_experiments_py.infrastructure.external.notebooklm_client.service_account.Credentials.from_service_account_file",
+            return_value=Mock(spec=service_account.Credentials),
+        ), patch(
+            "notebooklm_enterprise_experiments_py.infrastructure.external.notebooklm_client.discoveryengine.NotebookServiceClient",
+            return_value=Mock(),
+        ), patch(
+            "notebooklm_enterprise_experiments_py.infrastructure.external.notebooklm_client.discoveryengine.ConversationalSearchServiceClient",
+            return_value=Mock(),
+        ):
+            client = NotebookLMClient(
+                project_id="test-project",
+                location="global",
+            )
+            assert client.project_id == "test-project"
+            assert client.location == "global"
+
+    def test_init_without_credentials_raises_error(self) -> None:
+        """認証情報が設定されていない場合はエラーを発生させる。"""
+        with patch(
+            "notebooklm_enterprise_experiments_py.infrastructure.external.notebooklm_client.get_service_account_key_info",
+            return_value=None,
+        ), patch(
+            "notebooklm_enterprise_experiments_py.infrastructure.external.notebooklm_client.get_service_account_key_path",
+            return_value=None,
+        ):
+            with pytest.raises(
+                ValueError,
+                match="サービスアカウント認証情報が設定されていません",
+            ):
+                NotebookLMClient(
+                    project_id="test-project",
+                    location="global",
+                )
+
+    def test_create_notebook(self, mock_credentials: service_account.Credentials) -> None:
+        """ノートブックを作成できる。"""
+        mock_notebook_client = Mock()
+        mock_response = Mock()
+        mock_notebook_client.create_notebook = MagicMock(
+            return_value=mock_response
+        )
+
+        with patch(
+            "notebooklm_enterprise_experiments_py.infrastructure.external.notebooklm_client.discoveryengine.NotebookServiceClient",
+            return_value=mock_notebook_client,
+        ), patch(
+            "notebooklm_enterprise_experiments_py.infrastructure.external.notebooklm_client.discoveryengine.ConversationalSearchServiceClient",
+            return_value=Mock(),
+        ):
+            client = NotebookLMClient(
+                project_id="test-project",
+                location="global",
+                credentials=mock_credentials,
+            )
+
+            result = client.create_notebook(
+                notebook_id="test-notebook",
+                display_name="テストノートブック",
+            )
+
+            assert result == mock_response
+            mock_notebook_client.create_notebook.assert_called_once()
+            call_args = mock_notebook_client.create_notebook.call_args
+            assert call_args[1]["request"].notebook_id == "test-notebook"
+            assert call_args[1]["request"].notebook.display_name == "テストノートブック"
+
+    def test_add_sources(self, mock_credentials: service_account.Credentials) -> None:
+        """ソースを追加できる。"""
+        mock_notebook_client = Mock()
+        mock_operation = Mock()
+        mock_operation.result = MagicMock(return_value=None)
+        mock_notebook_client.import_notebook_sources = MagicMock(
+            return_value=mock_operation
+        )
+
+        with patch(
+            "notebooklm_enterprise_experiments_py.infrastructure.external.notebooklm_client.discoveryengine.NotebookServiceClient",
+            return_value=mock_notebook_client,
+        ), patch(
+            "notebooklm_enterprise_experiments_py.infrastructure.external.notebooklm_client.discoveryengine.ConversationalSearchServiceClient",
+            return_value=Mock(),
+        ):
+            client = NotebookLMClient(
+                project_id="test-project",
+                location="global",
+                credentials=mock_credentials,
+            )
+
+            client.add_sources(
+                notebook_id="test-notebook",
+                source_uris=["gs://bucket/doc1.pdf", "gs://bucket/doc2.pdf"],
+            )
+
+            mock_notebook_client.import_notebook_sources.assert_called_once()
+            call_args = mock_notebook_client.import_notebook_sources.call_args
+            assert len(call_args[1]["request"].gcs_source.uris) == 2
+            assert "gs://bucket/doc1.pdf" in call_args[1]["request"].gcs_source.uris
+            assert "gs://bucket/doc2.pdf" in call_args[1]["request"].gcs_source.uris
+
+    def test_ask(self, mock_credentials: service_account.Credentials) -> None:
+        """質問できる。"""
+        mock_conversational_client = Mock()
+        mock_answer = Mock()
+        mock_answer.answer_text = "これは回答です。"
+        mock_answer.citations = []
+        mock_response = Mock()
+        mock_response.answer = mock_answer
+        mock_conversational_client.answer = MagicMock(
+            return_value=mock_response
+        )
+
+        with patch(
+            "notebooklm_enterprise_experiments_py.infrastructure.external.notebooklm_client.discoveryengine.NotebookServiceClient",
+            return_value=Mock(),
+        ), patch(
+            "notebooklm_enterprise_experiments_py.infrastructure.external.notebooklm_client.discoveryengine.ConversationalSearchServiceClient",
+            return_value=mock_conversational_client,
+        ):
+            client = NotebookLMClient(
+                project_id="test-project",
+                location="global",
+                credentials=mock_credentials,
+            )
+
+            result = client.ask(
+                notebook_id="test-notebook",
+                query_text="最新の売上状況は？",
+            )
+
+            assert result == mock_response
+            mock_conversational_client.answer.assert_called_once()
+            call_args = mock_conversational_client.answer.call_args
+            assert call_args[1]["request"].query.text == "最新の売上状況は？"

--- a/tests/test_value_objects.py
+++ b/tests/test_value_objects.py
@@ -1,0 +1,126 @@
+"""値オブジェクトのテスト。"""
+
+import pytest
+
+from notebooklm_enterprise_experiments_py.domain.value_objects.answer import (
+    Answer,
+    Citation,
+)
+from notebooklm_enterprise_experiments_py.domain.value_objects.notebook_id import (
+    NotebookId,
+)
+from notebooklm_enterprise_experiments_py.domain.value_objects.query import Query
+
+
+class TestNotebookId:
+    """NotebookId値オブジェクトのテスト。"""
+
+    def test_valid_notebook_id(self) -> None:
+        """有効なNotebookIdを作成できる。"""
+        notebook_id = NotebookId("test-notebook-123")
+        assert notebook_id.value == "test-notebook-123"
+        assert str(notebook_id) == "test-notebook-123"
+
+    def test_empty_notebook_id_raises_error(self) -> None:
+        """空文字列のNotebookIdはエラーを発生させる。"""
+        with pytest.raises(ValueError, match="NotebookIdは空文字列にできません"):
+            NotebookId("")
+
+    def test_non_string_notebook_id_raises_error(self) -> None:
+        """文字列以外のNotebookIdはエラーを発生させる。"""
+        with pytest.raises(ValueError, match="NotebookIdは文字列である必要があります"):
+            NotebookId(123)  # type: ignore[arg-type]
+
+
+class TestQuery:
+    """Query値オブジェクトのテスト。"""
+
+    def test_valid_query(self) -> None:
+        """有効なQueryを作成できる。"""
+        query = Query("最新の売上状況は？")
+        assert query.text == "最新の売上状況は？"
+        assert str(query) == "最新の売上状況は？"
+
+    def test_empty_query_raises_error(self) -> None:
+        """空文字列のQueryはエラーを発生させる。"""
+        with pytest.raises(ValueError, match="Queryは空文字列にできません"):
+            Query("")
+
+    def test_non_string_query_raises_error(self) -> None:
+        """文字列以外のQueryはエラーを発生させる。"""
+        with pytest.raises(ValueError, match="Queryは文字列である必要があります"):
+            Query(123)  # type: ignore[arg-type]
+
+
+class TestCitation:
+    """Citation値オブジェクトのテスト。"""
+
+    def test_valid_citation(self) -> None:
+        """有効なCitationを作成できる。"""
+        citation = Citation(
+            source_title="技術ドキュメント",
+            content="住宅手当の申請期限は月末までです。",
+        )
+        assert citation.source_title == "技術ドキュメント"
+        assert citation.content == "住宅手当の申請期限は月末までです。"
+
+    def test_non_string_source_title_raises_error(self) -> None:
+        """文字列以外のsource_titleはエラーを発生させる。"""
+        with pytest.raises(ValueError, match="source_titleは文字列である必要があります"):
+            Citation(
+                source_title=123,  # type: ignore[arg-type]
+                content="test",
+            )
+
+    def test_non_string_content_raises_error(self) -> None:
+        """文字列以外のcontentはエラーを発生させる。"""
+        with pytest.raises(ValueError, match="contentは文字列である必要があります"):
+            Citation(
+                source_title="test",
+                content=123,  # type: ignore[arg-type]
+            )
+
+
+class TestAnswer:
+    """Answer値オブジェクトのテスト。"""
+
+    def test_valid_answer_without_citations(self) -> None:
+        """引用なしの有効なAnswerを作成できる。"""
+        answer = Answer(answer_text="これは回答です。")
+        assert answer.answer_text == "これは回答です。"
+        assert answer.citations == ()
+        assert str(answer) == "これは回答です。"
+
+    def test_valid_answer_with_citations(self) -> None:
+        """引用ありの有効なAnswerを作成できる。"""
+        citation1 = Citation(source_title="ドキュメント1", content="内容1")
+        citation2 = Citation(source_title="ドキュメント2", content="内容2")
+        answer = Answer(
+            answer_text="これは回答です。",
+            citations=(citation1, citation2),
+        )
+        assert answer.answer_text == "これは回答です。"
+        assert len(answer.citations) == 2
+        assert answer.citations[0] == citation1
+        assert answer.citations[1] == citation2
+
+    def test_non_string_answer_text_raises_error(self) -> None:
+        """文字列以外のanswer_textはエラーを発生させる。"""
+        with pytest.raises(ValueError, match="answer_textは文字列である必要があります"):
+            Answer(answer_text=123)  # type: ignore[arg-type]
+
+    def test_non_tuple_citations_raises_error(self) -> None:
+        """タプル以外のcitationsはエラーを発生させる。"""
+        with pytest.raises(ValueError, match="citationsはタプルである必要があります"):
+            Answer(
+                answer_text="test",
+                citations=[],  # type: ignore[arg-type]
+            )
+
+    def test_invalid_citation_type_raises_error(self) -> None:
+        """Citation以外の要素を含むcitationsはエラーを発生させる。"""
+        with pytest.raises(ValueError, match="citationsの要素はCitationである必要があります"):
+            Answer(
+                answer_text="test",
+                citations=("invalid",),  # type: ignore[arg-type]
+            )


### PR DESCRIPTION
## 概要
NotebookLM（Google Cloud Discovery Engine）を使用したノートブック管理機能の実装

## 変更内容

### ドメイン層
- `Notebook`エンティティの追加
- 値オブジェクトの追加
  - `NotebookId`: ノートブックIDを表す値オブジェクト
  - `Query`: クエリ（質問）を表す値オブジェクト
  - `Answer`: 回答を表す値オブジェクト
  - `Citation`: 引用情報を表す値オブジェクト
- `NotebookRepository`インターフェースの追加

### アプリケーション層
- `NotebookService`の実装
  - ノートブック作成機能
  - ソース追加機能
  - 質問機能
- DTOの追加
  - `CreateNotebookRequest/Response`
  - `AddSourcesRequest`
  - `AskRequest/Response`
  - `CitationDto`

### インフラストラクチャ層
- `NotebookLMClient`の実装（Google Cloud Discovery Engine APIとの連携）
- `NotebookRepositoryImpl`の実装
- 環境変数設定機能の追加（GCP関連）

### テスト
- エンティティ、値オブジェクト、リポジトリ、サービス、クライアントの包括的なテストを追加

## 統計
- 24ファイル変更
- 1,458行追加

## 関連
DDD（ドメイン駆動設計）の原則に基づいた実装